### PR TITLE
fix: react/jsx-indent-props to 2

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -8,6 +8,10 @@
         "react/jsx-indent": [
             2,
             2
+        ],
+        "react/jsx-indent-props": [
+            2,
+            2
         ]
     }
 }


### PR DESCRIPTION
Changes the rule "react/jsx-indent-props" to require 2 spaces
indentation, to keep it consistent with other indent rules.

Fixes: https://github.com/MailOnline/eslint-config-mailonline/issues/2
