### PR TITLE
fix: version-lock parent config

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,7 @@ Create ESLint configuration file (`.eslintrc`) that extends `eslint-config-mailo
     "extends": "mailonline"
 }
 ```
+
+## Breaking changes
+
+Any changes to this package that might cause code using it to not validate anymore, will be a semver-major change.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "eslint-config-airbnb": "^9.0.1"
   },
   "dependencies": {
-    "eslint-config-canonical": "^1.7.12"
+    "eslint-config-canonical": "1.8.8"
   }
 }


### PR DESCRIPTION
Lock eslint-config-canonical down to the patch to prevent
code that validated to suddenly not validate anymore on
CI environments and such.

From now on, any changes to this package that might make
code using it to not validate anymore, will have to
be a semver-major change.
