### PR TITLE
feat: relax filenames/match-regex regex

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -1,9 +1,16 @@
 {
-  "extends": ["canonical"],
+  "extends": [
+    "canonical"
+  ],
   "rules": {
     "arrow-body-style": [
       "error",
       "as-needed"
+    ],
+    "filenames/match-regex": [
+      2,
+      "^[A-Z]?[a-z]+(?:[A-Z][a-z]+)*(\\.[a-z]+)*$",
+      false
     ],
     "no-restricted-syntax": "off"
   }


### PR DESCRIPTION
modify filenames/match-regex regex to allow for "<dot><lovercase-word>"
nodes at the end of the filename.
Examples: webpackfile.prod.config.babel.js, myComponent.spec.js