### PR TITLE
feat: forbid anonymous defaults

### DIFF
--- a/eslintrc.json
+++ b/eslintrc.json
@@ -12,6 +12,17 @@
       "^[A-Z]?[a-z]+(?:[A-Z][a-z]+)*(\\.[a-z]+)*$",
       false
     ],
+    "import/no-anonymous-default-export": [
+      "error",
+      {
+        "allowAnonymousClass": false,
+        "allowAnonymousFunction": false,
+        "allowArray": false,
+        "allowArrowFunction": false,
+        "allowLiteral": false,
+        "allowObject": false
+      }
+    ],
     "no-restricted-syntax": "off",
     "react/forbid-component-props": "off",
     "react/jsx-no-bind": "off",


### PR DESCRIPTION
Everthing exported should be named. This change also discorages exports like:
```
export default {
  one,
  two,
  ...
}
```
Which prevent efficient treeshaking. As the compiler can't know what
can be needed on compile time.

BREAKING CHANGE: any anonymous export will fail from now on.