### PR TITLE
fix: move react overrides to react config

### DIFF
--- a/configurations/react.json
+++ b/configurations/react.json
@@ -1,0 +1,8 @@
+{
+  "extends": "canonical/react",
+  "rules": {
+    "react/forbid-component-props": "off",
+    "react/jsx-no-bind": "off",
+    "react/sort-prop-types": "off"
+  }
+}

--- a/eslintrc.json
+++ b/eslintrc.json
@@ -25,9 +25,6 @@
     ],
     "import/prefer-default-export": "off",
     "import/max-dependencies": "off",
-    "no-restricted-syntax": "off",
-    "react/forbid-component-props": "off",
-    "react/jsx-no-bind": "off",
-    "react/sort-prop-types": "off"
+    "no-restricted-syntax": "off"
   }
 }

--- a/react.js
+++ b/react.js
@@ -1,1 +1,1 @@
-module.exports = require('eslint-config-canonical/react');
+module.exports = require('./configurations/react.json');


### PR DESCRIPTION
There were some react overrides in the base config,
but they need to be in the react-specific config